### PR TITLE
chore: release 1.0

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -12,15 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-comment_width = 120
-edition = "2021"
-format_code_in_doc_comments = true
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-normalize_comments = true
-overflow_delimited_expr = true
-reorder_imports = true
-style_edition = "2024"
-trailing_comma = "Vertical"
-where_single_line = true
-wrap_comments = true
+# The pull request's title should be fulfilled the following pattern:
+#
+#     <type>[optional scope]: <description>
+#
+# ... where valid types and scopes can be found below; for example:
+#
+#     build(maven): One level down for native profile
+#
+# More about configurations on https://github.com/Ezard/semantic-prs#configuration
+
+enabled: true
+
+titleOnly: true
+
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+
+targetUrl: https://github.com/fast/exn/blob/main/.github/semantic.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 FastLabs Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: CI
 
 on:
@@ -5,6 +19,19 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+# Concurrency strategy:
+#   github.workflow: distinguish this workflow from others
+#   github.event_name: distinguish `push` event from `pull_request` event
+#   github.event.number: set to the number of the pull request if `pull_request` event
+#   github.run_id: otherwise, it's a `push` event, only cancel if we rerun the workflow
+#
+# Reference:
+#   https://docs.github.com/en/actions/using-jobs/using-concurrency
+#   https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,19 +42,27 @@ jobs:
     env:
       FORCE_COLOR: 1
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@master
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: rustfmt, clippy
+          components: rustfmt,clippy
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: typos-cli,taplo-cli,hawkeye
       - name: Cargo version
         run: cargo --version
       - name: Check format
         run: cargo fmt --all -- --check
       - name: Check clippy
         run: cargo clippy --all-targets --all-features -- --deny warnings
+      - name: Check typos
+        run: typos
+      - name: Check taplo
+        run: taplo check
+      - name: Run hawkeye
+        run: hawkeye check
 
   test:
     runs-on: ${{ matrix.os }}
@@ -35,25 +70,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
-        rust: [ "1.80.0", "stable", "nightly" ]
+        rust: [ "1.85.0", "stable", "nightly" ]
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-
       - name: Cargo version
         run: cargo --version
-
       - name: Build
         run: cargo build --workspace --all-targets
-
       - name: Build Release
         run: cargo build --workspace --all-targets --release
-
       - name: Run tests
-        run: |
-          cargo test
+        run: cargo test -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -28,53 +28,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "derive-visitor"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47165df83b9707cbada3216607a5d66125b6a66906de0bc1216c0669767ca9e"
-dependencies = [
- "derive-visitor-macros",
-]
-
-[[package]]
-name = "derive-visitor-macros"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427b39a85fecafea16b1a5f3f50437151022e35eb4fe038107f08adbf7f8def6"
-dependencies = [
- "convert_case",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "libc"
@@ -116,7 +73,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -173,7 +130,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn",
 ]
 
 [[package]]
@@ -199,7 +156,6 @@ dependencies = [
 name = "stacksafe"
 version = "1.0.0"
 dependencies = [
- "derive-visitor",
  "serde",
  "stacker",
  "stacksafe-macro",
@@ -211,18 +167,7 @@ version = "1.0.0"
 dependencies = [
  "proc-macro-error2",
  "quote",
- "syn 2.0.108",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -238,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,29 @@
 version = 4
 
 [[package]]
-name = "cc"
-version = "1.2.25"
+name = "ar_archive_writer"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
 dependencies = [
+ "object",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "convert_case"
@@ -52,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,9 +78,24 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -85,54 +116,64 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
 dependencies = [
+ "ar_archive_writer",
  "cc",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -143,9 +184,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "stacker"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
 dependencies = [
  "cc",
  "cfg-if",
@@ -156,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "stacksafe"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "derive-visitor",
  "serde",
@@ -166,11 +207,11 @@ dependencies = [
 
 [[package]]
 name = "stacksafe-macro"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "proc-macro-error2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -186,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -197,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ stacksafe = { version = "1.0.0", path = "stacksafe" }
 stacksafe-macro = { version = "=1.0.0", path = "stacksafe-macro" }
 
 # crates.io dependencies
-derive-visitor = { version = "0.4" }
 proc-macro-error2 = { version = "2" }
 quote = { version = "1" }
 serde = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,37 @@
+# Copyright 2025 FastLabs Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [workspace]
 members = ["stacksafe", "stacksafe-macro"]
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/fast/stacksafe"
-rust-version = "1.80.0"
-version = "0.1.4"
+rust-version = "1.85.0"
+version = "1.0.0"
 
 [workspace.dependencies]
 # workspace dependencies
-stacksafe = { version = "0.1.4", path = "stacksafe" }
-stacksafe-macro = { version = "=0.1.4", path = "stacksafe-macro" }
+stacksafe = { version = "1.0.0", path = "stacksafe" }
+stacksafe-macro = { version = "=1.0.0", path = "stacksafe-macro" }
 
 # crates.io dependencies
-derive-visitor = "0.4"
-proc-macro-error2 = "2"
-quote = "1"
-serde = "1"
-stacker = "0.1"
-syn = "2"
+derive-visitor = { version = "0.4" }
+proc-macro-error2 = { version = "2" }
+quote = { version = "1" }
+serde = { version = "1" }
+stacker = { version = "0.1" }
+syn = { version = "2" }

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ set_stack_allocation_size(4 * 1024 * 1024);
 StackSafe supports several optional features:
 
 - `serde`: Provides stack-safe serialization and deserialization for `StackSafe<T>`.
-- `derive-visitor`: Provides stack-safe visitor pattern implementations for `StackSafe<T>`.
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/stacksafe.svg?style=flat-square&logo=rust)](https://crates.io/crates/stacksafe)
 [![Documentation](https://img.shields.io/docsrs/stacksafe?style=flat-square&logo=rust)](https://docs.rs/stacksafe/)
-[![MSRV 1.80.0](https://img.shields.io/badge/MSRV-1.80.0-green?style=flat-square&logo=rust)](https://www.whatrustisit.com)
+[![MSRV 1.85.0](https://img.shields.io/badge/MSRV-1.85.0-green?style=flat-square&logo=rust)](https://www.whatrustisit.com)
 [![CI Status](https://img.shields.io/github/actions/workflow/status/fast/stacksafe/ci.yml?style=flat-square&logo=github)](https://github.com/fast/stacksafe/actions)
 
 StackSafe prevents stack overflows in deeply recursive algorithms by providing intelligent stack management. No more crashes from recursive functions or data structures that exceed the default stack size - StackSafe automatically allocates additional stack space when needed, eliminating the need for manual stack size tuning or complex refactoring to iterative approaches.
@@ -13,7 +13,7 @@ Add StackSafe to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-stacksafe = "0.1"
+stacksafe = "1"
 ```
 
 Transform recursive functions with the `#[stacksafe]` attribute to prevent stack overflow:
@@ -64,8 +64,10 @@ fn tree_sum(tree: &BinaryTree) -> i32 {
 ## How It Works
 
 - `#[stacksafe]` attribute monitors remaining stack space at function entry points. When available space falls below a threshold (default: 128 KiB), it automatically allocates a new stack segment (default: 2 MiB) and continues execution.
-
 - `StackSafe<T>` is a wrapper type that transparently implement common traits like `Clone`, `Debug`, and `PartialEq` with `#[stacksafe]` support, allowing you to use it in recursive data structures without losing functionality.
+- In `debug` builds, accessing `StackSafe<T>` performs additional checks to ensure the current function is properly annotated with `#[stacksafe]`, helping catch potential issues during development.
+
+Read this [blog post](https://fast.github.io/blog/stacksafe-taming-recursion-in-rust-without-stack-overflow/) for an in-depth explanation of StackSafe's design and implementation.
 
 ## Configuration
 

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -12,15 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-comment_width = 120
-edition = "2021"
-format_code_in_doc_comments = true
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-normalize_comments = true
-overflow_delimited_expr = true
-reorder_imports = true
-style_edition = "2024"
-trailing_comma = "Vertical"
-where_single_line = true
-wrap_comments = true
+headerPath = "Apache-2.0.txt"
+
+includes = ['**/*.proto', '**/*.rs', '**/*.yml', '**/*.yaml', '**/*.toml']
+
+[properties]
+copyrightOwner = "FastLabs Developers"
+inceptionYear = 2025

--- a/stacksafe-macro/Cargo.toml
+++ b/stacksafe-macro/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2025 FastLabs Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "stacksafe-macro"
 

--- a/stacksafe-macro/src/lib.rs
+++ b/stacksafe-macro/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Procedural macro implementation for the `stacksafe` crate.
 //!
 //! This crate provides the `#[stacksafe]` attribute macro that transforms functions
@@ -49,7 +63,6 @@ pub fn stacksafe(args: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let mut item_fn = item_fn;
-    let block = item_fn.block;
     let ret = match &item_fn.sig.output {
         // impl trait is not supported in closure return type, override with
         // default, which is inferring.
@@ -58,7 +71,7 @@ pub fn stacksafe(args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let stacksafe_crate = crate_path.unwrap_or_else(|| parse_quote!(::stacksafe));
-
+    let block = &item_fn.block;
     let wrapped_block = quote! {
         {
             #stacksafe_crate::internal::stacker::maybe_grow(
@@ -68,6 +81,7 @@ pub fn stacksafe(args: TokenStream, item: TokenStream) -> TokenStream {
             )
         }
     };
-    item_fn.block = Box::new(syn::parse(wrapped_block.into()).unwrap());
+
+    *item_fn.block = syn::parse(wrapped_block.into()).unwrap();
     item_fn.into_token_stream().into()
 }

--- a/stacksafe/Cargo.toml
+++ b/stacksafe/Cargo.toml
@@ -32,13 +32,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-# Provides stack-safe visitor pattern implementations for `StackSafe<T>`.
-derive-visitor = ["dep:derive-visitor"]
 # Provides stack-safe serialization and deserialization for `StackSafe<T>`.
 serde = ["dep:serde"]
 
 [dependencies]
-derive-visitor = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 stacker = { workspace = true }
 stacksafe-macro = { workspace = true }

--- a/stacksafe/Cargo.toml
+++ b/stacksafe/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2025 FastLabs Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "stacksafe"
 

--- a/stacksafe/src/internal.rs
+++ b/stacksafe/src/internal.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![doc(hidden)]
 
 pub use stacker;

--- a/stacksafe/src/lib.rs
+++ b/stacksafe/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! StackSafe prevents stack overflows in deeply recursive algorithms by providing intelligent stack
 //! management. No more crashes from recursive functions or data structures that exceed the default
 //! stack size - StackSafe automatically allocates additional stack space when needed, eliminating
@@ -9,7 +23,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! stacksafe = "0.1"
+//! stacksafe = "1"
 //! ```
 //!
 //! Transform recursive functions with the [`#[stacksafe]`](stacksafe) attribute to prevent stack
@@ -68,6 +82,13 @@
 //!   [`Debug`], and [`PartialEq`] with `#[stacksafe]` support, ensuring stack-safe operations on
 //!   recursive data structures without risking overflow.
 //!
+//! - In `debug` builds, accessing [`StackSafe<T>`] performs additional checks to ensure the current
+//!   function is properly annotated with `#[stacksafe]`, helping catch potential issues during
+//!   development.
+//!
+//! Read this [blog post](https://fast.github.io/blog/stacksafe-taming-recursion-in-rust-without-stack-overflow/)
+//! for an in-depth explanation of StackSafe's design and implementation.
+//!
 //! ## Configuration
 //!
 //! Customize stack management behavior:
@@ -101,7 +122,7 @@
 //! - And more...
 
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod internal;
 

--- a/stacksafe/src/lib.rs
+++ b/stacksafe/src/lib.rs
@@ -109,7 +109,6 @@
 //! StackSafe supports several optional features:
 //!
 //! - `serde`: Provides stack-safe serialization and deserialization for [`StackSafe<T>`].
-//! - `derive-visitor`: Provides stack-safe visitor pattern implementations for [`StackSafe<T>`].
 //!
 //! ## Platform Support
 //!
@@ -432,21 +431,5 @@ impl<'a, T: serde::Deserialize<'a>> serde::Deserialize<'a> for StackSafe<T> {
     fn deserialize<D: serde::Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
         let value = T::deserialize(deserializer)?;
         Ok(StackSafe(std::mem::ManuallyDrop::new(value)))
-    }
-}
-
-#[cfg(feature = "derive-visitor")]
-impl<T: derive_visitor::Drive> derive_visitor::Drive for StackSafe<T> {
-    #[stacksafe(crate = crate)]
-    fn drive<V: derive_visitor::Visitor>(&self, visitor: &mut V) {
-        self.0.drive(visitor);
-    }
-}
-
-#[cfg(feature = "derive-visitor")]
-impl<T: derive_visitor::DriveMut> derive_visitor::DriveMut for StackSafe<T> {
-    #[stacksafe(crate = crate)]
-    fn drive_mut<V: derive_visitor::VisitorMut>(&mut self, visitor: &mut V) {
-        self.0.drive_mut(visitor);
     }
 }

--- a/stacksafe/tests/test.rs
+++ b/stacksafe/tests/test.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt::Display;
 
 #[stacksafe::stacksafe]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,3 +1,17 @@
+# Copyright 2025 FastLabs Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include = ["Cargo.toml", "**/*.toml"]
 
 [formatting]


### PR DESCRIPTION
This closes #8.

Since we're going to use [`traversable`](https://github.com/fast/visitor/pull/6) to integrate the visitor pattern, not sure if we should still keep `derive-visitor` feature flag: it does not harm, but may spread discouraged practice.