### PR TITLE
chore: upgrade syn to 3.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -202,7 +202,7 @@ version = "1.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -210,6 +210,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.45" }
 serde = { version = "1.0.228" }
 stacker = { version = "0.1.24" }
-syn = { version = "2.0.117" }
+syn = { version = "3.0.3" }
 trybuild = { version = "1.0.116" }


### PR DESCRIPTION
## Summary

- upgrade the workspace `syn` dependency from 2.0.117 to 3.0.3
- refresh `Cargo.lock` so `stacksafe-macro` resolves `syn` 3.x

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- --deny warnings`
- `cargo test -- --nocapture`
- `cargo build --workspace --all-targets --release`
- `cargo +1.85.0 build --workspace --all-targets`
- `cargo +1.85.0 test -- --nocapture`
- `taplo check`
- `typos`
- `hawkeye check`